### PR TITLE
Point PurgeCSS at the right files

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -7,7 +7,7 @@ module.exports = {
 		...(process.env.NODE_ENV === "production"
 			? [
 					require("@fullhuman/postcss-purgecss")({
-						content: ["./pages/**/*.jsx", "./components/**/*.jsx"],
+						content: ["./pages/**/*.js", "./core/**/*.jsx"],
 						defaultExtractor: content => content.match(/[\w-/:]+(?<!:)/g) || []
 					})
 			  ]


### PR DESCRIPTION
This PR prevents PurgeCSS from removing all Tailwind styles. In a previous iteration, this app had React components in two directories: `/pages` and  `/components`. Now nearly all components are in `/core`, but we hadn't updated the PurgeCSS configuration. Therefore, with this change we teach PurgeCSS where to look for CSS selectors.