### PR TITLE
Ensure session cookies are sent correctly in production

### DIFF
--- a/core/auth/setup.js
+++ b/core/auth/setup.js
@@ -28,6 +28,12 @@ function setupAuth(server) {
 			saveUninitialized: false
 		})
 	);
+	// If the app is hosted behind a proxy, this setting is required
+	// to ensure that cookies with 'secure' set to true are properly
+	// sent to the server when Auth0 redirects the user to the /callback
+	// route. See https://github.com/auth0/passport-auth0/issues/70#issuecomment-480771614
+	// for more details.
+	isDev && server.set("trust proxy", 1);
 
 	// Set up authentication through Auth0
 	const passport = require("passport");


### PR DESCRIPTION
This PR fixes the authentication flow with Auth0 in production. Previously, the app would get caught in an infinite redirect loop when Auth0 redirected the user back to the `/callback` route. This is because the app (I think) is hosted behind a proxy, meaning the sessions cookies were not being correctly sent along with the redirect. Therefore, the server gave the redirected user a new session, which caused the Auth0 strategy to fail.

This problem attempts to fix this bug by trusting the proxy in front of the application server. This fix is based the suggestion at https://github.com/auth0/passport-auth0/issues/70#issuecomment-480771614.