### PR TITLE
Change app name and add page titles

### DIFF
--- a/core/homepage/Home.jsx
+++ b/core/homepage/Home.jsx
@@ -12,7 +12,7 @@ function Home() {
 		return (
 			<>
 				<Head>
-					<title>Your Feed &mdash; Castaway</title>
+					<title>Your Feed &mdash; a11yPod</title>
 				</Head>
 				<EmptyState>
 					<EmptyState.Heading>Your Feed: Coming Soon 🚧</EmptyState.Heading>

--- a/core/homepage/Welcome.jsx
+++ b/core/homepage/Welcome.jsx
@@ -8,13 +8,13 @@ export default function Welcome() {
 	return (
 		<>
 			<Head>
-				<title>Castaway &mdash; Your podcasts, organized.</title>
+				<title>a11yPod &mdash; The accessible podcast app</title>
 			</Head>
 			<EmptyState>
-				<EmptyState.Heading>Your podcasts, organized.</EmptyState.Heading>
+				<EmptyState.Heading>a11yPod</EmptyState.Heading>
 				<EmptyState.Blurb>
-					Castaway helps you manage your favorite podcasts. Subscribe to
-					channels and save episodes to listen later.
+					a11yPod is a demo podcast app that prioritizes accessibility. Log in
+					to your account or search podcasts right away.
 				</EmptyState.Blurb>
 				<EmptyState.Actions>
 					<LoginButton className="button--lg">Get started</LoginButton>

--- a/core/nav/Navbar.jsx
+++ b/core/nav/Navbar.jsx
@@ -14,20 +14,18 @@ function NavBar() {
 				Skip navigation
 			</a>
 			<Link href="/">
-				<a className="p-3 order-1 font-bold text-lg sm:py-0 sm:px-6">
-					Castaway
-				</a>
+				<a className="p-3 order-1 font-bold text-lg sm:py-0 sm:px-6">a11yPod</a>
 			</Link>
 			<nav className="text-center ml-auto w-full order-4 sm:order-3 sm:w-auto">
 				<ul className="flex">
 					<li className="flex-grow">
-						<NavLink href="/">Home</NavLink>
+						<NavLink href="/">{user ? "Your Feed" : "Home"}</NavLink>
 					</li>
 					<li className="flex-grow">
 						<NavLink href="/search">Search</NavLink>
 					</li>
 					<li className="flex-grow">
-						<NavLink href="/playlist">Your List</NavLink>
+						<NavLink href="/playlist">Playlist</NavLink>
 					</li>
 				</ul>
 			</nav>

--- a/core/playlist/Playlist.jsx
+++ b/core/playlist/Playlist.jsx
@@ -12,7 +12,7 @@ function Playlist() {
 		return (
 			<>
 				<Head>
-					<title>Your Playlist &mdash; Castaway</title>
+					<title>Your Playlist &mdash; a11yPod</title>
 				</Head>
 				<EmptyState>
 					<EmptyState.Heading>Your Playlist: Coming Soon 🚧</EmptyState.Heading>
@@ -29,16 +29,21 @@ function Playlist() {
 		);
 	} else {
 		return (
-			<EmptyState>
-				<EmptyState.Heading>Your List</EmptyState.Heading>
-				<EmptyState.Blurb>
-					Saved episodes will appear here. Log in or create an account to get
-					started.
-				</EmptyState.Blurb>
-				<EmptyState.Actions>
-					<LoginButton className="button--lg">Get Started</LoginButton>
-				</EmptyState.Actions>
-			</EmptyState>
+			<>
+				<Head>
+					<title>Your Playlist &mdash; a11yPod</title>
+				</Head>
+				<EmptyState>
+					<EmptyState.Heading>Your Playlist</EmptyState.Heading>
+					<EmptyState.Blurb>
+						Saved episodes will appear here. Log in or create an account to get
+						started.
+					</EmptyState.Blurb>
+					<EmptyState.Actions>
+						<LoginButton className="button--lg">Get Started</LoginButton>
+					</EmptyState.Actions>
+				</EmptyState>
+			</>
 		);
 	}
 }

--- a/core/search/Search.jsx
+++ b/core/search/Search.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import Head from "next/head";
 import { useFetch, IfPending, IfFulfilled, IfRejected } from "react-async";
 import uniqBy from "lodash/fp/uniqBy";
 import SearchInput from "./SearchInput";
@@ -114,85 +115,93 @@ function Search() {
 	const onChange = e => setTerm(e.target.value);
 
 	return (
-		<div className="page">
-			<h1 className="sr-only">Search</h1>
-			<form role="search" aria-label="Podcasts" className="pb-3 sm:pb-6">
-				<SearchInput
-					id="podcast-search"
-					placeholder="Search podcasts"
-					value={term}
-					onChange={onChange}
-				/>
-			</form>
-			<div
-				id="result-count-alert"
-				className="sr-only"
-				role="alert"
-				aria-live="polite"
-			>
-				<IfPending state={search}>Loading results.</IfPending>
+		<>
+			<Head>
+				<title>Search Podcasts &mdash; a11yPod</title>
+			</Head>
+			<div className="page">
+				<h1 className="sr-only">Search</h1>
+				<form role="search" aria-label="Podcasts" className="pb-3 sm:pb-6">
+					<SearchInput
+						id="podcast-search"
+						placeholder="Search podcasts"
+						value={term}
+						onChange={onChange}
+					/>
+				</form>
+				<div
+					id="result-count-alert"
+					className="sr-only"
+					role="alert"
+					aria-live="polite"
+				>
+					<IfPending state={search}>Loading results.</IfPending>
+					<IfRejected state={search}>
+						There was an error retrieving the search results.
+					</IfRejected>
+					<IfFulfilled state={search}>
+						{({ results, term }) => {
+							if (term) {
+								return `Found ${results.length} ${
+									results.length === 1 ? "result" : "results"
+								} for '${term}'.`;
+							} else {
+								return "Type a search term into the form above to get results.";
+							}
+						}}
+					</IfFulfilled>
+				</div>
+				<IfPending state={search}>
+					<div className="page__blurb my-auto text-center" aria-hidden="true">
+						Loading&hellip;
+					</div>
+				</IfPending>
 				<IfRejected state={search}>
-					There was an error retrieving the search results.
+					<div className="page__blurb my-auto text-center" aria-hidden="true">
+						There was an error retrieving the search results. 😔
+					</div>
 				</IfRejected>
 				<IfFulfilled state={search}>
 					{({ results, term }) => {
 						if (term) {
-							return `Found ${results.length} ${
-								results.length === 1 ? "result" : "results"
-							} for '${term}'.`;
+							return (
+								<>
+									<div
+										className="text-sm text-gray-700 mb-3"
+										aria-hidden="true"
+									>
+										Found {results.length}{" "}
+										{results.length === 1 ? "result" : "results"} for &ldquo;
+										{term}&rdquo;
+									</div>
+									<aside className="bg-yellow-300 text-sm p-3 sm:px-6 -mx-3 sm:-mx-6">
+										<strong>🚧 Links to podcasts are coming soon.</strong> For
+										now, search results do not link anywhere else.
+									</aside>
+									<CardStack
+										className="-mx-3 sm:-mx-6"
+										aria-label="Search results"
+									>
+										{results.map(podcast => (
+											<PodcastPreview key={podcast.id} {...podcast} />
+										))}
+									</CardStack>
+								</>
+							);
 						} else {
-							return "Type a search term into the form above to get results.";
+							return (
+								<div
+									className="page__blurb my-auto text-center"
+									aria-hidden="true"
+								>
+									Type a search term above to see results here.
+								</div>
+							);
 						}
 					}}
 				</IfFulfilled>
 			</div>
-			<IfPending state={search}>
-				<div className="page__blurb my-auto text-center" aria-hidden="true">
-					Loading&hellip;
-				</div>
-			</IfPending>
-			<IfRejected state={search}>
-				<div className="page__blurb my-auto text-center" aria-hidden="true">
-					There was an error retrieving the search results. 😔
-				</div>
-			</IfRejected>
-			<IfFulfilled state={search}>
-				{({ results, term }) => {
-					if (term) {
-						return (
-							<>
-								<div className="text-sm text-gray-700 mb-3" aria-hidden="true">
-									Found {results.length}{" "}
-									{results.length === 1 ? "result" : "results"} for &ldquo;
-									{term}&rdquo;
-								</div>
-								<aside className="bg-yellow-300 text-sm p-3 sm:px-6 -mx-3 sm:-mx-6">
-									<strong>🚧 Links to podcasts are coming soon.</strong> For
-									now, search results do not link anywhere else.
-								</aside>
-								<CardStack
-									className="-mx-3 sm:-mx-6"
-									aria-label="Search results"
-								>
-									{results.map(podcast => (
-										<PodcastPreview key={podcast.id} {...podcast} />
-									))}
-								</CardStack>
-							</>
-						);
-					} else {
-						return (
-							<div
-								className="page__blurb my-auto text-center"
-								aria-hidden="true"
-							>
-								Type a search term above to see results here.
-							</div>
-						);
-					}
-				}}
-			</IfFulfilled>
-		</div>
+		</>
 	);
 }
 

--- a/core/store/index.js
+++ b/core/store/index.js
@@ -10,7 +10,7 @@ import { createStore } from "easy-peasy";
 import StoreModel from "./StoreModel";
 
 const isServer = typeof window === "undefined";
-const __CASTAWAY_CLIENT_STORE__ = "__CASTAWAY_CLIENT_STORE__";
+const __A11YPOD_CLIENT_STORE__ = "__A11YPOD_CLIENT_STORE__";
 
 /**
  * @returns {import("easy-peasy").Store<StoreModel>}
@@ -22,11 +22,11 @@ export function getOrCreateStore(initialState) {
 	}
 
 	// Create and save store if none yet exists
-	if (!window[__CASTAWAY_CLIENT_STORE__]) {
-		window[__CASTAWAY_CLIENT_STORE__] = createStore(StoreModel, {
+	if (!window[__A11YPOD_CLIENT_STORE__]) {
+		window[__A11YPOD_CLIENT_STORE__] = createStore(StoreModel, {
 			initialState
 		});
 	}
 
-	return window[__CASTAWAY_CLIENT_STORE__];
+	return window[__A11YPOD_CLIENT_STORE__];
 }


### PR DESCRIPTION
This PR changes the app name from "Castaway" to "a11yPod" (see #11). The new name avoids conflict with existing IP and better communicates the main priority of the app: accessibility. This PR also adds all page titles (using the new name) to all pages.

This PR closes #9 and closes #11.