### PR TITLE
Fix layout bugs in navbar and search results

### DIFF
--- a/core/nav/Navbar.jsx
+++ b/core/nav/Navbar.jsx
@@ -18,13 +18,13 @@ function NavBar() {
 			</Link>
 			<nav className="text-center ml-auto w-full order-4 sm:order-3 sm:w-auto">
 				<ul className="flex">
-					<li className="flex-grow">
+					<li className="flex-grow w-1/3 sm:w-auto">
 						<NavLink href="/">{user ? "Your Feed" : "Home"}</NavLink>
 					</li>
-					<li className="flex-grow">
+					<li className="flex-grow w-1/3 sm:w-auto">
 						<NavLink href="/search">Search</NavLink>
 					</li>
-					<li className="flex-grow">
+					<li className="flex-grow w-1/3 sm:w-auto">
 						<NavLink href="/playlist">Playlist</NavLink>
 					</li>
 				</ul>

--- a/core/podcasts/PodcastPreview.jsx
+++ b/core/podcasts/PodcastPreview.jsx
@@ -6,7 +6,7 @@ function PodcastPreview({ title, publisher, thumbnail }) {
 		<article>
 			<div className="flex items-start">
 				<img
-					className="w-16 h-16 bg-gray-200 mr-3"
+					className="w-16 h-16 bg-gray-200 flex-shrink-0 mr-3"
 					src={thumbnail._100w}
 					srcSet={Object.keys(thumbnail)
 						.map(width => `${thumbnail[width]} ${width.slice(1)}`)


### PR DESCRIPTION
This PR fixes two flexbox-related layout bugs:

1. The tabs in the navbar were not evenly distributed on mobile. This PR fixes that by setting them each to fill up a third of the total width on small viewports.
2. The thumbnails in podcast previews could be squeezed into rectangles by long titles or publisher names. This PR fixes that by setting `flex-shrink: 0` on the thumbnails.

This PR closes #10.