### PR TITLE
Add search permalinks and pagination

### DIFF
--- a/core/components/Card.jsx
+++ b/core/components/Card.jsx
@@ -8,9 +8,11 @@ const cardPropTypes = {
 	className: PropTypes.string
 };
 
-function Card({ as: Component = "div", className, children }) {
+function Card({ as: Component = "div", className, children, ...otherProps }) {
 	return (
-		<Component className={classNames("card", className)}>{children}</Component>
+		<Component {...otherProps} className={classNames("card", className)}>
+			{children}
+		</Component>
 	);
 }
 

--- a/core/components/CardStack.jsx
+++ b/core/components/CardStack.jsx
@@ -3,11 +3,15 @@ import PropTypes from "prop-types";
 import classNames from "classnames";
 import { StackedCard } from "./Card";
 
-function CardStack({ className, children, ...otherProps }) {
+function CardStack({ className, children, listRef, ...otherProps }) {
 	return (
-		<ul className={classNames("card-stack", className)} {...otherProps}>
+		<ul
+			className={classNames("card-stack", className)}
+			ref={listRef}
+			{...otherProps}
+		>
 			{React.Children.map(children, child => (
-				<StackedCard as="li" className="card-stack__item">
+				<StackedCard as="li" className="card-stack__item" tabIndex="-1">
 					{child}
 				</StackedCard>
 			))}
@@ -17,7 +21,8 @@ function CardStack({ className, children, ...otherProps }) {
 
 CardStack.propTypes = {
 	children: PropTypes.node,
-	className: PropTypes.string
+	className: PropTypes.string,
+	listRef: PropTypes.object
 };
 
 export default CardStack;

--- a/core/env.js
+++ b/core/env.js
@@ -3,5 +3,7 @@ const graphqlRoute = "/api/v1/graphql";
 module.exports = {
 	isDev: process.env.NODE_ENV !== "production",
 	baseUrl: process.env.BASE_URL,
-	graphqlEndpoint: this.baseUrl ? this.baseUrl + graphqlRoute : graphqlRoute
+	graphqlEndpoint: process.env.BASE_URL
+		? process.env.BASE_URL + graphqlRoute
+		: graphqlRoute
 };

--- a/core/graphql/client.js
+++ b/core/graphql/client.js
@@ -20,20 +20,16 @@ export function initGraphqlRequest({ headers, ...otherConfig } = {}) {
  * @param {RequestInit} config
  */
 export async function fetchGraphql(config = {}) {
-	try {
-		const { data, errors } = await (await fetch(
-			graphqlEndpoint,
-			initGraphqlRequest(config)
-		)).json();
+	const { data, errors } = await (await fetch(
+		graphqlEndpoint,
+		initGraphqlRequest(config)
+	)).json();
 
-		if (errors) {
-			throw new Error(
-				`${errors[0].extensions.code || "UNKNOWN_ERROR"}: ${errors[0].message}`
-			);
-		}
-
-		return data;
-	} catch (e) {
-		if (e.name !== "AbortError") throw e;
+	if (errors) {
+		throw new Error(
+			`${errors[0].extensions.code || "UNKNOWN_ERROR"}: ${errors[0].message}`
+		);
 	}
+
+	return data;
 }

--- a/core/graphql/client.js
+++ b/core/graphql/client.js
@@ -1,0 +1,39 @@
+import fetch from "isomorphic-unfetch";
+import { graphqlEndpoint } from "../env";
+
+/**
+ * @param {RequestInit} config
+ */
+export function initGraphqlRequest({ headers, ...otherConfig } = {}) {
+	return {
+		...otherConfig,
+		headers: {
+			...headers,
+			Accept: "application/json",
+			"Content-Type": "application/json"
+		},
+		method: "POST"
+	};
+}
+
+/**
+ * @param {RequestInit} config
+ */
+export async function fetchGraphql(config = {}) {
+	try {
+		const { data, errors } = await (await fetch(
+			graphqlEndpoint,
+			initGraphqlRequest(config)
+		)).json();
+
+		if (errors) {
+			throw new Error(
+				`${errors[0].extensions.code || "UNKNOWN_ERROR"}: ${errors[0].message}`
+			);
+		}
+
+		return data;
+	} catch (e) {
+		if (e.name !== "AbortError") throw e;
+	}
+}

--- a/core/graphql/client.test.js
+++ b/core/graphql/client.test.js
@@ -57,8 +57,3 @@ it("should throw when fetch errors", () => {
 	mockFetchReject({ reason: error });
 	return expect(fetchGraphql()).rejects.toThrow(error);
 });
-
-it("should not throw when the fetch is aborted", () => {
-	mockFetchReject({ reason: { name: "AbortError" } });
-	return expect(fetchGraphql()).resolves.toBeUndefined();
-});

--- a/core/graphql/client.test.js
+++ b/core/graphql/client.test.js
@@ -1,0 +1,64 @@
+import { fetchGraphql } from "./client";
+import { graphqlEndpoint } from "../env";
+
+jest.mock("isomorphic-unfetch");
+import fetch from "isomorphic-unfetch";
+import { createFetchMocks } from "../test-helpers";
+const { mockFetchResolve, mockFetchReject } = createFetchMocks(fetch);
+
+afterEach(fetch.mockClear);
+
+it("should request and return data from the GraphQL endpoint", async () => {
+	expect.assertions(2);
+
+	// Mock fetch to resolve with data for a GraphQL query
+	const response = { data: { hello: "world" } };
+	mockFetchResolve({ json: response });
+
+	// Send the query
+	const query = `query { hello }`;
+	const body = JSON.stringify({ query });
+	const data = await fetchGraphql({ body });
+
+	expect(fetch).toHaveBeenCalledWith(
+		graphqlEndpoint,
+		expect.objectContaining({
+			body,
+			method: "POST",
+			headers: {
+				Accept: "application/json",
+				"Content-Type": "application/json"
+			}
+		})
+	);
+	expect(data).toBe(response.data);
+});
+
+it("should throw when the GraphQL endpoint returns an error", () => {
+	// Mock fetch to resolve with errors in the GraphQL response
+	mockFetchResolve({
+		json: {
+			data: null,
+			errors: [
+				{
+					message: "Database crashed",
+					extensions: { code: "INTERNAL_SERVER_ERROR" }
+				}
+			]
+		}
+	});
+	return expect(fetchGraphql()).rejects.toThrow(
+		"INTERNAL_SERVER_ERROR: Database crashed"
+	);
+});
+
+it("should throw when fetch errors", () => {
+	const error = new Error("fetch failed");
+	mockFetchReject({ reason: error });
+	return expect(fetchGraphql()).rejects.toThrow(error);
+});
+
+it("should not throw when the fetch is aborted", () => {
+	mockFetchReject({ reason: { name: "AbortError" } });
+	return expect(fetchGraphql()).resolves.toBeUndefined();
+});

--- a/core/podcasts/PodcastsModel.js
+++ b/core/podcasts/PodcastsModel.js
@@ -9,13 +9,13 @@ const PodcastsModel = {
 			state.items[podcast.id] = podcast;
 		}
 	}),
-	search: thunk(async (actions, payload) => {
+	search: thunk(async (actions, { term, offset = 0, signal } = {}) => {
 		const data = await fetchGraphql({
 			body: JSON.stringify({
 				query,
-				variables: { term: payload.term }
+				variables: { term, offset }
 			}),
-			signal: payload.signal
+			signal
 		});
 
 		actions.addBatch(data.searchPodcasts.results);

--- a/core/podcasts/PodcastsModel.js
+++ b/core/podcasts/PodcastsModel.js
@@ -1,3 +1,26 @@
-const PodcastsModel = {};
+import { fetchGraphql } from "../graphql/client";
+import query from "./SearchQuery.graphql";
+import { action, thunk } from "easy-peasy";
+
+const PodcastsModel = {
+	items: {},
+	addBatch: action((state, payload) => {
+		for (const podcast of payload) {
+			state.items[podcast.id] = podcast;
+		}
+	}),
+	search: thunk(async (actions, payload) => {
+		const data = await fetchGraphql({
+			body: JSON.stringify({
+				query,
+				variables: { term: payload.term }
+			}),
+			signal: payload.signal
+		});
+
+		actions.addBatch(data.searchPodcasts.results);
+		return data.searchPodcasts;
+	})
+};
 
 export default PodcastsModel;

--- a/core/podcasts/PodcastsModel.test.js
+++ b/core/podcasts/PodcastsModel.test.js
@@ -1,5 +1,13 @@
 import PodcastsModel from "./PodcastsModel";
 import { createStore as createEasyPeasyStore } from "easy-peasy";
+import { graphqlEndpoint } from "../env";
+
+jest.mock("isomorphic-unfetch");
+import fetch from "isomorphic-unfetch";
+import { createFetchMocks } from "../test-helpers";
+const { mockFetchResolve } = createFetchMocks(fetch);
+
+import apiResponse from "./__fixtures__/gql-search-podcasts.json";
 
 // eslint-disable-next-line no-unused-vars
 function createStore() {
@@ -8,6 +16,33 @@ function createStore() {
 	});
 }
 
+afterEach(fetch.mockClear);
+
 describe("search", () => {
-	it("should query the GraphQL endpoint and return the results", () => {});
+	it("should query the GraphQL endpoint and return the results", async () => {
+		expect.assertions(2);
+
+		mockFetchResolve({ json: apiResponse });
+		const store = createStore();
+
+		const results = await store.getActions().podcasts.search({ term: "vox" });
+		expect(results).toMatchSnapshot();
+		expect(fetch).toHaveBeenCalledWith(
+			graphqlEndpoint,
+			expect.objectContaining({
+				body: expect.stringContaining(`"term":"vox"`)
+			})
+		);
+	});
+
+	it("should update the store with the response", async () => {
+		expect.assertions(1);
+
+		mockFetchResolve({ json: apiResponse });
+		const store = createStore();
+
+		await store.getActions().podcasts.search({ term: "vox" });
+
+		expect(store.getState().podcasts.items).toMatchSnapshot();
+	});
 });

--- a/core/podcasts/__fixtures__/gql-search-podcasts.json
+++ b/core/podcasts/__fixtures__/gql-search-podcasts.json
@@ -1,6 +1,7 @@
 {
 	"data": {
 		"searchPodcasts": {
+			"term": "vox",
 			"startIndex": 0,
 			"nextOffset": 5,
 			"results": [
@@ -12,10 +13,10 @@
 					"iTunesUrl": "https://podcasts.apple.com/us/podcast/the-weeds/id1042433083?uo=4",
 					"feedUrl": "https://feeds.megaphone.fm/theweeds",
 					"thumbnail": {
-						"w30": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts113/v4/c6/89/4c/c6894cfa-5084-c9fe-3c72-666978686bb4/mza_1739210204902964516.png/30x30bb.jpg",
-						"w60": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts113/v4/c6/89/4c/c6894cfa-5084-c9fe-3c72-666978686bb4/mza_1739210204902964516.png/60x60bb.jpg",
-						"w100": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts113/v4/c6/89/4c/c6894cfa-5084-c9fe-3c72-666978686bb4/mza_1739210204902964516.png/100x100bb.jpg",
-						"w600": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts113/v4/c6/89/4c/c6894cfa-5084-c9fe-3c72-666978686bb4/mza_1739210204902964516.png/600x600bb.jpg"
+						"_30w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts113/v4/c6/89/4c/c6894cfa-5084-c9fe-3c72-666978686bb4/mza_1739210204902964516.png/30x30bb.jpg",
+						"_60w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts113/v4/c6/89/4c/c6894cfa-5084-c9fe-3c72-666978686bb4/mza_1739210204902964516.png/60x60bb.jpg",
+						"_100w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts113/v4/c6/89/4c/c6894cfa-5084-c9fe-3c72-666978686bb4/mza_1739210204902964516.png/100x100bb.jpg",
+						"_600w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts113/v4/c6/89/4c/c6894cfa-5084-c9fe-3c72-666978686bb4/mza_1739210204902964516.png/600x600bb.jpg"
 					}
 				},
 				{
@@ -26,10 +27,10 @@
 					"iTunesUrl": "https://podcasts.apple.com/us/podcast/the-ezra-klein-show/id1081584611?uo=4",
 					"feedUrl": "https://feeds.megaphone.fm/theezrakleinshow",
 					"thumbnail": {
-						"w30": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts113/v4/7a/17/0f/7a170fc0-97ae-64be-eeb7-9ecf9330581d/mza_1082450096055116974.png/30x30bb.jpg",
-						"w60": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts113/v4/7a/17/0f/7a170fc0-97ae-64be-eeb7-9ecf9330581d/mza_1082450096055116974.png/60x60bb.jpg",
-						"w100": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts113/v4/7a/17/0f/7a170fc0-97ae-64be-eeb7-9ecf9330581d/mza_1082450096055116974.png/100x100bb.jpg",
-						"w600": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts113/v4/7a/17/0f/7a170fc0-97ae-64be-eeb7-9ecf9330581d/mza_1082450096055116974.png/600x600bb.jpg"
+						"_30w": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts113/v4/7a/17/0f/7a170fc0-97ae-64be-eeb7-9ecf9330581d/mza_1082450096055116974.png/30x30bb.jpg",
+						"_60w": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts113/v4/7a/17/0f/7a170fc0-97ae-64be-eeb7-9ecf9330581d/mza_1082450096055116974.png/60x60bb.jpg",
+						"_100w": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts113/v4/7a/17/0f/7a170fc0-97ae-64be-eeb7-9ecf9330581d/mza_1082450096055116974.png/100x100bb.jpg",
+						"_600w": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts113/v4/7a/17/0f/7a170fc0-97ae-64be-eeb7-9ecf9330581d/mza_1082450096055116974.png/600x600bb.jpg"
 					}
 				},
 				{
@@ -40,10 +41,10 @@
 					"iTunesUrl": "https://podcasts.apple.com/us/podcast/the-impact/id1294325824?uo=4",
 					"feedUrl": "https://feeds.megaphone.fm/impact",
 					"thumbnail": {
-						"w30": "https://is2-ssl.mzstatic.com/image/thumb/Podcasts113/v4/24/ef/39/24ef396a-1ae5-6e79-e661-20fdea200f93/mza_3156222670743834797.png/30x30bb.jpg",
-						"w60": "https://is2-ssl.mzstatic.com/image/thumb/Podcasts113/v4/24/ef/39/24ef396a-1ae5-6e79-e661-20fdea200f93/mza_3156222670743834797.png/60x60bb.jpg",
-						"w100": "https://is2-ssl.mzstatic.com/image/thumb/Podcasts113/v4/24/ef/39/24ef396a-1ae5-6e79-e661-20fdea200f93/mza_3156222670743834797.png/100x100bb.jpg",
-						"w600": "https://is2-ssl.mzstatic.com/image/thumb/Podcasts113/v4/24/ef/39/24ef396a-1ae5-6e79-e661-20fdea200f93/mza_3156222670743834797.png/600x600bb.jpg"
+						"_30w": "https://is2-ssl.mzstatic.com/image/thumb/Podcasts113/v4/24/ef/39/24ef396a-1ae5-6e79-e661-20fdea200f93/mza_3156222670743834797.png/30x30bb.jpg",
+						"_60w": "https://is2-ssl.mzstatic.com/image/thumb/Podcasts113/v4/24/ef/39/24ef396a-1ae5-6e79-e661-20fdea200f93/mza_3156222670743834797.png/60x60bb.jpg",
+						"_100w": "https://is2-ssl.mzstatic.com/image/thumb/Podcasts113/v4/24/ef/39/24ef396a-1ae5-6e79-e661-20fdea200f93/mza_3156222670743834797.png/100x100bb.jpg",
+						"_600w": "https://is2-ssl.mzstatic.com/image/thumb/Podcasts113/v4/24/ef/39/24ef396a-1ae5-6e79-e661-20fdea200f93/mza_3156222670743834797.png/600x600bb.jpg"
 					}
 				},
 				{
@@ -54,10 +55,10 @@
 					"iTunesUrl": "https://podcasts.apple.com/us/podcast/switched-on-pop/id934552872?uo=4",
 					"feedUrl": "https://feeds.megaphone.fm/switchedonpop",
 					"thumbnail": {
-						"w30": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/f3/d1/22/f3d12254-e15b-4b1b-6558-74470f0b93ae/mza_2025196989843407248.png/30x30bb.jpg",
-						"w60": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/f3/d1/22/f3d12254-e15b-4b1b-6558-74470f0b93ae/mza_2025196989843407248.png/60x60bb.jpg",
-						"w100": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/f3/d1/22/f3d12254-e15b-4b1b-6558-74470f0b93ae/mza_2025196989843407248.png/100x100bb.jpg",
-						"w600": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/f3/d1/22/f3d12254-e15b-4b1b-6558-74470f0b93ae/mza_2025196989843407248.png/600x600bb.jpg"
+						"_30w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/f3/d1/22/f3d12254-e15b-4b1b-6558-74470f0b93ae/mza_2025196989843407248.png/30x30bb.jpg",
+						"_60w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/f3/d1/22/f3d12254-e15b-4b1b-6558-74470f0b93ae/mza_2025196989843407248.png/60x60bb.jpg",
+						"_100w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/f3/d1/22/f3d12254-e15b-4b1b-6558-74470f0b93ae/mza_2025196989843407248.png/100x100bb.jpg",
+						"_600w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/f3/d1/22/f3d12254-e15b-4b1b-6558-74470f0b93ae/mza_2025196989843407248.png/600x600bb.jpg"
 					}
 				},
 				{
@@ -68,10 +69,10 @@
 					"iTunesUrl": "https://podcasts.apple.com/us/podcast/worldly/id1248862589?uo=4",
 					"feedUrl": "https://feeds.megaphone.fm/worldly",
 					"thumbnail": {
-						"w30": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/08/2e/07/082e079a-cabf-db62-3fea-a74cc8a1b594/mza_1165648460994853372.png/30x30bb.jpg",
-						"w60": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/08/2e/07/082e079a-cabf-db62-3fea-a74cc8a1b594/mza_1165648460994853372.png/60x60bb.jpg",
-						"w100": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/08/2e/07/082e079a-cabf-db62-3fea-a74cc8a1b594/mza_1165648460994853372.png/100x100bb.jpg",
-						"w600": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/08/2e/07/082e079a-cabf-db62-3fea-a74cc8a1b594/mza_1165648460994853372.png/600x600bb.jpg"
+						"_30w": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/08/2e/07/082e079a-cabf-db62-3fea-a74cc8a1b594/mza_1165648460994853372.png/30x30bb.jpg",
+						"_60w": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/08/2e/07/082e079a-cabf-db62-3fea-a74cc8a1b594/mza_1165648460994853372.png/60x60bb.jpg",
+						"_100w": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/08/2e/07/082e079a-cabf-db62-3fea-a74cc8a1b594/mza_1165648460994853372.png/100x100bb.jpg",
+						"_600w": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/08/2e/07/082e079a-cabf-db62-3fea-a74cc8a1b594/mza_1165648460994853372.png/600x600bb.jpg"
 					}
 				}
 			]

--- a/core/podcasts/__snapshots__/PodcastsModel.test.js.snap
+++ b/core/podcasts/__snapshots__/PodcastsModel.test.js.snap
@@ -1,0 +1,186 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`search should query the GraphQL endpoint and return the results 1`] = `
+Object {
+  "nextOffset": 5,
+  "results": Array [
+    Object {
+      "feedUrl": "https://feeds.megaphone.fm/theweeds",
+      "genre": "Politics",
+      "iTunesUrl": "https://podcasts.apple.com/us/podcast/the-weeds/id1042433083?uo=4",
+      "id": "1042433083",
+      "publisher": Object {
+        "id": "1439215748",
+        "name": "Vox",
+      },
+      "thumbnail": Object {
+        "_100w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts113/v4/c6/89/4c/c6894cfa-5084-c9fe-3c72-666978686bb4/mza_1739210204902964516.png/100x100bb.jpg",
+        "_30w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts113/v4/c6/89/4c/c6894cfa-5084-c9fe-3c72-666978686bb4/mza_1739210204902964516.png/30x30bb.jpg",
+        "_600w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts113/v4/c6/89/4c/c6894cfa-5084-c9fe-3c72-666978686bb4/mza_1739210204902964516.png/600x600bb.jpg",
+        "_60w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts113/v4/c6/89/4c/c6894cfa-5084-c9fe-3c72-666978686bb4/mza_1739210204902964516.png/60x60bb.jpg",
+      },
+      "title": "The Weeds",
+    },
+    Object {
+      "feedUrl": "https://feeds.megaphone.fm/theezrakleinshow",
+      "genre": "Philosophy",
+      "iTunesUrl": "https://podcasts.apple.com/us/podcast/the-ezra-klein-show/id1081584611?uo=4",
+      "id": "1081584611",
+      "publisher": Object {
+        "id": "1439215748",
+        "name": "Vox",
+      },
+      "thumbnail": Object {
+        "_100w": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts113/v4/7a/17/0f/7a170fc0-97ae-64be-eeb7-9ecf9330581d/mza_1082450096055116974.png/100x100bb.jpg",
+        "_30w": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts113/v4/7a/17/0f/7a170fc0-97ae-64be-eeb7-9ecf9330581d/mza_1082450096055116974.png/30x30bb.jpg",
+        "_600w": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts113/v4/7a/17/0f/7a170fc0-97ae-64be-eeb7-9ecf9330581d/mza_1082450096055116974.png/600x600bb.jpg",
+        "_60w": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts113/v4/7a/17/0f/7a170fc0-97ae-64be-eeb7-9ecf9330581d/mza_1082450096055116974.png/60x60bb.jpg",
+      },
+      "title": "The Ezra Klein Show",
+    },
+    Object {
+      "feedUrl": "https://feeds.megaphone.fm/impact",
+      "genre": "Documentary",
+      "iTunesUrl": "https://podcasts.apple.com/us/podcast/the-impact/id1294325824?uo=4",
+      "id": "1294325824",
+      "publisher": Object {
+        "id": "1439215748",
+        "name": "Vox",
+      },
+      "thumbnail": Object {
+        "_100w": "https://is2-ssl.mzstatic.com/image/thumb/Podcasts113/v4/24/ef/39/24ef396a-1ae5-6e79-e661-20fdea200f93/mza_3156222670743834797.png/100x100bb.jpg",
+        "_30w": "https://is2-ssl.mzstatic.com/image/thumb/Podcasts113/v4/24/ef/39/24ef396a-1ae5-6e79-e661-20fdea200f93/mza_3156222670743834797.png/30x30bb.jpg",
+        "_600w": "https://is2-ssl.mzstatic.com/image/thumb/Podcasts113/v4/24/ef/39/24ef396a-1ae5-6e79-e661-20fdea200f93/mza_3156222670743834797.png/600x600bb.jpg",
+        "_60w": "https://is2-ssl.mzstatic.com/image/thumb/Podcasts113/v4/24/ef/39/24ef396a-1ae5-6e79-e661-20fdea200f93/mza_3156222670743834797.png/60x60bb.jpg",
+      },
+      "title": "The Impact",
+    },
+    Object {
+      "feedUrl": "https://feeds.megaphone.fm/switchedonpop",
+      "genre": "Music Commentary",
+      "iTunesUrl": "https://podcasts.apple.com/us/podcast/switched-on-pop/id934552872?uo=4",
+      "id": "934552872",
+      "publisher": Object {
+        "id": "1439215748",
+        "name": "Vox",
+      },
+      "thumbnail": Object {
+        "_100w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/f3/d1/22/f3d12254-e15b-4b1b-6558-74470f0b93ae/mza_2025196989843407248.png/100x100bb.jpg",
+        "_30w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/f3/d1/22/f3d12254-e15b-4b1b-6558-74470f0b93ae/mza_2025196989843407248.png/30x30bb.jpg",
+        "_600w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/f3/d1/22/f3d12254-e15b-4b1b-6558-74470f0b93ae/mza_2025196989843407248.png/600x600bb.jpg",
+        "_60w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/f3/d1/22/f3d12254-e15b-4b1b-6558-74470f0b93ae/mza_2025196989843407248.png/60x60bb.jpg",
+      },
+      "title": "Switched on Pop",
+    },
+    Object {
+      "feedUrl": "https://feeds.megaphone.fm/worldly",
+      "genre": "Politics",
+      "iTunesUrl": "https://podcasts.apple.com/us/podcast/worldly/id1248862589?uo=4",
+      "id": "1248862589",
+      "publisher": Object {
+        "id": "1439215748",
+        "name": "Vox",
+      },
+      "thumbnail": Object {
+        "_100w": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/08/2e/07/082e079a-cabf-db62-3fea-a74cc8a1b594/mza_1165648460994853372.png/100x100bb.jpg",
+        "_30w": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/08/2e/07/082e079a-cabf-db62-3fea-a74cc8a1b594/mza_1165648460994853372.png/30x30bb.jpg",
+        "_600w": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/08/2e/07/082e079a-cabf-db62-3fea-a74cc8a1b594/mza_1165648460994853372.png/600x600bb.jpg",
+        "_60w": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/08/2e/07/082e079a-cabf-db62-3fea-a74cc8a1b594/mza_1165648460994853372.png/60x60bb.jpg",
+      },
+      "title": "Worldly",
+    },
+  ],
+  "startIndex": 0,
+  "term": "vox",
+}
+`;
+
+exports[`search should update the store with the response 1`] = `
+Object {
+  "1042433083": Object {
+    "feedUrl": "https://feeds.megaphone.fm/theweeds",
+    "genre": "Politics",
+    "iTunesUrl": "https://podcasts.apple.com/us/podcast/the-weeds/id1042433083?uo=4",
+    "id": "1042433083",
+    "publisher": Object {
+      "id": "1439215748",
+      "name": "Vox",
+    },
+    "thumbnail": Object {
+      "_100w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts113/v4/c6/89/4c/c6894cfa-5084-c9fe-3c72-666978686bb4/mza_1739210204902964516.png/100x100bb.jpg",
+      "_30w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts113/v4/c6/89/4c/c6894cfa-5084-c9fe-3c72-666978686bb4/mza_1739210204902964516.png/30x30bb.jpg",
+      "_600w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts113/v4/c6/89/4c/c6894cfa-5084-c9fe-3c72-666978686bb4/mza_1739210204902964516.png/600x600bb.jpg",
+      "_60w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts113/v4/c6/89/4c/c6894cfa-5084-c9fe-3c72-666978686bb4/mza_1739210204902964516.png/60x60bb.jpg",
+    },
+    "title": "The Weeds",
+  },
+  "1081584611": Object {
+    "feedUrl": "https://feeds.megaphone.fm/theezrakleinshow",
+    "genre": "Philosophy",
+    "iTunesUrl": "https://podcasts.apple.com/us/podcast/the-ezra-klein-show/id1081584611?uo=4",
+    "id": "1081584611",
+    "publisher": Object {
+      "id": "1439215748",
+      "name": "Vox",
+    },
+    "thumbnail": Object {
+      "_100w": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts113/v4/7a/17/0f/7a170fc0-97ae-64be-eeb7-9ecf9330581d/mza_1082450096055116974.png/100x100bb.jpg",
+      "_30w": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts113/v4/7a/17/0f/7a170fc0-97ae-64be-eeb7-9ecf9330581d/mza_1082450096055116974.png/30x30bb.jpg",
+      "_600w": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts113/v4/7a/17/0f/7a170fc0-97ae-64be-eeb7-9ecf9330581d/mza_1082450096055116974.png/600x600bb.jpg",
+      "_60w": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts113/v4/7a/17/0f/7a170fc0-97ae-64be-eeb7-9ecf9330581d/mza_1082450096055116974.png/60x60bb.jpg",
+    },
+    "title": "The Ezra Klein Show",
+  },
+  "1248862589": Object {
+    "feedUrl": "https://feeds.megaphone.fm/worldly",
+    "genre": "Politics",
+    "iTunesUrl": "https://podcasts.apple.com/us/podcast/worldly/id1248862589?uo=4",
+    "id": "1248862589",
+    "publisher": Object {
+      "id": "1439215748",
+      "name": "Vox",
+    },
+    "thumbnail": Object {
+      "_100w": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/08/2e/07/082e079a-cabf-db62-3fea-a74cc8a1b594/mza_1165648460994853372.png/100x100bb.jpg",
+      "_30w": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/08/2e/07/082e079a-cabf-db62-3fea-a74cc8a1b594/mza_1165648460994853372.png/30x30bb.jpg",
+      "_600w": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/08/2e/07/082e079a-cabf-db62-3fea-a74cc8a1b594/mza_1165648460994853372.png/600x600bb.jpg",
+      "_60w": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/08/2e/07/082e079a-cabf-db62-3fea-a74cc8a1b594/mza_1165648460994853372.png/60x60bb.jpg",
+    },
+    "title": "Worldly",
+  },
+  "1294325824": Object {
+    "feedUrl": "https://feeds.megaphone.fm/impact",
+    "genre": "Documentary",
+    "iTunesUrl": "https://podcasts.apple.com/us/podcast/the-impact/id1294325824?uo=4",
+    "id": "1294325824",
+    "publisher": Object {
+      "id": "1439215748",
+      "name": "Vox",
+    },
+    "thumbnail": Object {
+      "_100w": "https://is2-ssl.mzstatic.com/image/thumb/Podcasts113/v4/24/ef/39/24ef396a-1ae5-6e79-e661-20fdea200f93/mza_3156222670743834797.png/100x100bb.jpg",
+      "_30w": "https://is2-ssl.mzstatic.com/image/thumb/Podcasts113/v4/24/ef/39/24ef396a-1ae5-6e79-e661-20fdea200f93/mza_3156222670743834797.png/30x30bb.jpg",
+      "_600w": "https://is2-ssl.mzstatic.com/image/thumb/Podcasts113/v4/24/ef/39/24ef396a-1ae5-6e79-e661-20fdea200f93/mza_3156222670743834797.png/600x600bb.jpg",
+      "_60w": "https://is2-ssl.mzstatic.com/image/thumb/Podcasts113/v4/24/ef/39/24ef396a-1ae5-6e79-e661-20fdea200f93/mza_3156222670743834797.png/60x60bb.jpg",
+    },
+    "title": "The Impact",
+  },
+  "934552872": Object {
+    "feedUrl": "https://feeds.megaphone.fm/switchedonpop",
+    "genre": "Music Commentary",
+    "iTunesUrl": "https://podcasts.apple.com/us/podcast/switched-on-pop/id934552872?uo=4",
+    "id": "934552872",
+    "publisher": Object {
+      "id": "1439215748",
+      "name": "Vox",
+    },
+    "thumbnail": Object {
+      "_100w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/f3/d1/22/f3d12254-e15b-4b1b-6558-74470f0b93ae/mza_2025196989843407248.png/100x100bb.jpg",
+      "_30w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/f3/d1/22/f3d12254-e15b-4b1b-6558-74470f0b93ae/mza_2025196989843407248.png/30x30bb.jpg",
+      "_600w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/f3/d1/22/f3d12254-e15b-4b1b-6558-74470f0b93ae/mza_2025196989843407248.png/600x600bb.jpg",
+      "_60w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/f3/d1/22/f3d12254-e15b-4b1b-6558-74470f0b93ae/mza_2025196989843407248.png/60x60bb.jpg",
+    },
+    "title": "Switched on Pop",
+  },
+}
+`;

--- a/core/search/Search.jsx
+++ b/core/search/Search.jsx
@@ -1,80 +1,147 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import { useStoreActions } from "easy-peasy";
-import { useAsync, IfPending, IfFulfilled, IfRejected } from "react-async";
-import uniqBy from "lodash/fp/uniqBy";
+import useSearch, { SearchStatus } from "./useSearch";
 import SearchInput from "./SearchInput";
 import CardStack from "../components/CardStack";
 import PodcastPreview from "../podcasts/PodcastPreview";
 
-const INITIAL_DATA = {
-	term: "",
-	startIndex: 0,
-	nextOffset: null,
-	results: []
+const SearchStateProps = {
+	term: PropTypes.string.isRequired,
+	results: PropTypes.array.isRequired,
+	status: PropTypes.oneOf(Object.values(SearchStatus)).isRequired,
+	loadMoreResults: PropTypes.func
 };
 
-/**
- * Keep only unique podcasts
- */
-const dedupe = uniqBy("id");
+function SearchAlertMessage({ term, results, status }) {
+	switch (status) {
+		case SearchStatus.OK:
+			if (!term) {
+				return "Enter a search term to load results.";
+			} else {
+				return `Found ${results.length} ${
+					results.length === 1 ? "result" : "results"
+				} for term "${term}".`;
+			}
+		case SearchStatus.LOADING_NEW:
+			return `Loading results for term "${term}".`;
+		case SearchStatus.FAILED_NEW:
+			return `There was an error retrieving results for term "${term}".`;
+		case SearchStatus.LOADING_MORE:
+			return `Loading more results for term "${term}".`;
+		case SearchStatus.FAILED_MORE:
+			return `There was an error retrieving more results for term "${term}".`;
+		default:
+			throw new Error();
+	}
+}
 
-/**
- * Intercepts actions dispatched by `react-async`'s `useAsync()` hook to
- * handle the following special case: The fetch fulfilled and the search
- * term in the new data is the same as the current search term. This happens
- * when the user requests more results for the same term, in which case we
- * don't want to blow away the existing results. Therefore, we check whether
- * the old term and new term match, and if they do, we append the new results
- * to the old. Repeated results are removed.
- * @type {import("react-async").AsyncOptions<SearchResults>["reducer"]}
- */
-const reducer = (state, action, internalReducer) => {
-	if (action.type === "fulfill" && action.payload.term === state.data.term) {
-		action.payload.results = dedupe([
-			...state.data.results,
-			...action.payload.results
-		]);
+SearchAlertMessage.propTypes = SearchStateProps;
+
+function SearchResults({ term, results, status, listRef }) {
+	switch (status) {
+		case SearchStatus.LOADING_NEW:
+			return (
+				<div className="page__blurb my-auto text-center" aria-hidden="true">
+					Loading&hellip;
+				</div>
+			);
+		case SearchStatus.FAILED_NEW:
+			return (
+				<div className="page__blurb my-auto text-center" aria-hidden="true">
+					There was an error retrieving the search results. 😔
+				</div>
+			);
+		case SearchStatus.OK:
+		default:
+			if (!term) {
+				return (
+					<div className="page__blurb my-auto text-center" aria-hidden="true">
+						Type a search term above to see results here.
+					</div>
+				);
+			} else {
+				return (
+					<>
+						<div className="text-sm text-gray-700 mb-3" aria-hidden="true">
+							Found {results.length}{" "}
+							{results.length === 1 ? "result" : "results"} for &ldquo;
+							{term}&rdquo;
+						</div>
+						<aside className="bg-yellow-300 text-sm p-3 sm:px-6 -mx-3 sm:-mx-6">
+							<strong>🚧 Links to podcasts are coming soon.</strong> For now,
+							search results do not link anywhere else.
+						</aside>
+						<CardStack
+							className="-mx-3 sm:-mx-6"
+							aria-label="Search results"
+							listRef={listRef}
+						>
+							{results.map(podcast => (
+								<PodcastPreview key={podcast.id} {...podcast} />
+							))}
+						</CardStack>
+					</>
+				);
+			}
+	}
+}
+
+SearchResults.propTypes = {
+	...SearchStateProps,
+	listRef: PropTypes.object
+};
+
+function SearchLoadMoreButton({ loadMoreResults, status }) {
+	if (!loadMoreResults) {
+		return null;
 	}
 
-	return internalReducer(state, action);
-};
+	if (status === SearchStatus.LOADING_MORE) {
+		return <div className="mt-3 sm:mt-6 text-center">Loading&hellip;</div>;
+	}
 
-function Search({ initialTerm = "", initialValue = INITIAL_DATA }) {
-	const router = useRouter();
-	const [term, setTerm] = useState(initialTerm);
-	const searchPodcasts = useStoreActions(actions => actions.podcasts.search);
-	const deferFn = useCallback(
-		(args, props, { signal }) => {
-			return searchPodcasts({ ...args[0], signal });
-		},
-		[searchPodcasts]
+	return (
+		<div className="mt-3 sm:mt-6 text-center">
+			<button
+				className="button button--secondary button--lg"
+				type="button"
+				onClick={loadMoreResults}
+			>
+				Load more results
+			</button>
+			{status === SearchStatus.FAILED_MORE && (
+				<div className="mt-2 p-2 bg-red-200 text-red-700" aria-hidden="true">
+					There was an error loading more results.
+				</div>
+			)}
+		</div>
 	);
-	const search = useAsync({
-		initialValue,
-		deferFn,
-		reducer
-	});
+}
 
-	useEffect(() => {
-		if (!term) {
-			search.setData(INITIAL_DATA);
-		} else if (search.value.term !== term) {
-			search.run({ term });
-			return search.cancel;
-		}
-	}, [term, search.value.term, search.setData, search.run, search.cancel]);
+SearchLoadMoreButton.propTypes = SearchStateProps;
+
+function Search({ initialTerm, initialValue }) {
+	const router = useRouter();
+	const state = useSearch({ initialTerm, initialValue });
+	const resultsList = useRef(null);
 
 	useEffect(() => {
 		if (router) {
-			const href = "/search?q=" + term;
+			const href = "/search?q=" + state.term;
 			router.replace(href, href, { shallow: true });
 		}
-	}, [term]);
+	}, [state.term]);
 
-	const onChange = e => setTerm(e.target.value);
+	useEffect(() => {
+		if (resultsList.current && state.focusOnResult !== null) {
+			// focus on the first new result whenever more results are loaded
+			resultsList.current.children[state.focusOnResult].focus();
+		}
+	}, [state.focusOnResult]);
+
+	const onChange = e => state.updateSearchTerm(e.target.value);
 
 	return (
 		<>
@@ -87,7 +154,7 @@ function Search({ initialTerm = "", initialValue = INITIAL_DATA }) {
 					<SearchInput
 						id="podcast-search"
 						placeholder="Search podcasts"
-						value={term}
+						value={state.term}
 						onChange={onChange}
 					/>
 				</form>
@@ -97,71 +164,10 @@ function Search({ initialTerm = "", initialValue = INITIAL_DATA }) {
 					role="alert"
 					aria-live="polite"
 				>
-					<IfPending state={search}>Loading results.</IfPending>
-					<IfRejected state={search}>
-						There was an error retrieving the search results.
-					</IfRejected>
-					<IfFulfilled state={search}>
-						{({ results, term }) => {
-							if (term) {
-								return `Found ${results.length} ${
-									results.length === 1 ? "result" : "results"
-								} for '${term}'.`;
-							} else {
-								return "Type a search term into the form above to get results.";
-							}
-						}}
-					</IfFulfilled>
+					<SearchAlertMessage {...state} />
 				</div>
-				<IfPending state={search}>
-					<div className="page__blurb my-auto text-center" aria-hidden="true">
-						Loading&hellip;
-					</div>
-				</IfPending>
-				<IfRejected state={search}>
-					<div className="page__blurb my-auto text-center" aria-hidden="true">
-						There was an error retrieving the search results. 😔
-					</div>
-				</IfRejected>
-				<IfFulfilled state={search}>
-					{({ results, term }) => {
-						if (term) {
-							return (
-								<>
-									<div
-										className="text-sm text-gray-700 mb-3"
-										aria-hidden="true"
-									>
-										Found {results.length}{" "}
-										{results.length === 1 ? "result" : "results"} for &ldquo;
-										{term}&rdquo;
-									</div>
-									<aside className="bg-yellow-300 text-sm p-3 sm:px-6 -mx-3 sm:-mx-6">
-										<strong>🚧 Links to podcasts are coming soon.</strong> For
-										now, search results do not link anywhere else.
-									</aside>
-									<CardStack
-										className="-mx-3 sm:-mx-6"
-										aria-label="Search results"
-									>
-										{results.map(podcast => (
-											<PodcastPreview key={podcast.id} {...podcast} />
-										))}
-									</CardStack>
-								</>
-							);
-						} else {
-							return (
-								<div
-									className="page__blurb my-auto text-center"
-									aria-hidden="true"
-								>
-									Type a search term above to see results here.
-								</div>
-							);
-						}
-					}}
-				</IfFulfilled>
+				<SearchResults {...state} listRef={resultsList} />
+				<SearchLoadMoreButton {...state} />
 			</div>
 		</>
 	);
@@ -169,8 +175,7 @@ function Search({ initialTerm = "", initialValue = INITIAL_DATA }) {
 
 Search.getInitialProps = async function({ query, store }) {
 	const props = {
-		initialTerm: query.q || "",
-		initialValue: INITIAL_DATA
+		initialTerm: query.q || ""
 	};
 
 	if (props.initialTerm) {

--- a/core/search/__fixtures__/search-results-end-of-results.json
+++ b/core/search/__fixtures__/search-results-end-of-results.json
@@ -1,0 +1,96 @@
+{
+	"data": {
+		"searchPodcasts": {
+			"term": "vox",
+			"startIndex": 5,
+			"nextOffset": null,
+			"results": [
+				{
+					"id": "1210802178",
+					"title": "I Think You're Interesting",
+					"genre": "TV Reviews",
+					"publisher": {
+						"id": "1439215748",
+						"name": "Vox"
+					},
+					"iTunesUrl": "https://podcasts.apple.com/us/podcast/i-think-youre-interesting/id1210802178?uo=4",
+					"feedUrl": "https://feeds.megaphone.fm/ithinkyoureinteresting",
+					"thumbnail": {
+						"_30w": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/78/e6/dc/78e6dc55-1c41-b8d6-6c0b-6ee02c0fcb1c/mza_2458197206222672008.png/30x30bb.jpg",
+						"_60w": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/78/e6/dc/78e6dc55-1c41-b8d6-6c0b-6ee02c0fcb1c/mza_2458197206222672008.png/60x60bb.jpg",
+						"_100w": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/78/e6/dc/78e6dc55-1c41-b8d6-6c0b-6ee02c0fcb1c/mza_2458197206222672008.png/100x100bb.jpg",
+						"_600w": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/78/e6/dc/78e6dc55-1c41-b8d6-6c0b-6ee02c0fcb1c/mza_2458197206222672008.png/600x600bb.jpg"
+					}
+				},
+				{
+					"id": "1438157174",
+					"title": "Future Perfect",
+					"genre": "Philosophy",
+					"publisher": {
+						"id": "1439215748",
+						"name": "Vox"
+					},
+					"iTunesUrl": "https://podcasts.apple.com/us/podcast/future-perfect/id1438157174?uo=4",
+					"feedUrl": "https://feeds.megaphone.fm/futureperfect",
+					"thumbnail": {
+						"_30w": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/01/69/a6/0169a699-7bfd-c1a4-2323-5fab57620a39/mza_4433840416936287580.png/30x30bb.jpg",
+						"_60w": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/01/69/a6/0169a699-7bfd-c1a4-2323-5fab57620a39/mza_4433840416936287580.png/60x60bb.jpg",
+						"_100w": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/01/69/a6/0169a699-7bfd-c1a4-2323-5fab57620a39/mza_4433840416936287580.png/100x100bb.jpg",
+						"_600w": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/01/69/a6/0169a699-7bfd-c1a4-2323-5fab57620a39/mza_4433840416936287580.png/600x600bb.jpg"
+					}
+				},
+				{
+					"id": "1460319105",
+					"title": "Primetime",
+					"genre": "TV Reviews",
+					"publisher": {
+						"id": "1439215748",
+						"name": "Vox"
+					},
+					"iTunesUrl": "https://podcasts.apple.com/us/podcast/primetime/id1460319105?uo=4",
+					"feedUrl": "https://feeds.megaphone.fm/primetime",
+					"thumbnail": {
+						"_30w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/85/7c/0e/857c0edb-aca0-8f46-8f84-4a1c14e74a3f/mza_5367935943215259933.png/30x30bb.jpg",
+						"_60w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/85/7c/0e/857c0edb-aca0-8f46-8f84-4a1c14e74a3f/mza_5367935943215259933.png/60x60bb.jpg",
+						"_100w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/85/7c/0e/857c0edb-aca0-8f46-8f84-4a1c14e74a3f/mza_5367935943215259933.png/100x100bb.jpg",
+						"_600w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/85/7c/0e/857c0edb-aca0-8f46-8f84-4a1c14e74a3f/mza_5367935943215259933.png/600x600bb.jpg"
+					}
+				},
+				{
+					"id": "1346207297",
+					"title": "Today, Explained",
+					"genre": "Daily News",
+					"publisher": {
+						"id": "1439215748",
+						"name": "Vox and Stitcher"
+					},
+					"iTunesUrl": "https://podcasts.apple.com/us/podcast/today-explained/id1346207297?uo=4",
+					"feedUrl": "https://rss.art19.com/today-explained",
+					"thumbnail": {
+						"_30w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/04/c1/48/04c1486a-6637-00de-6e89-264b48ed82f7/mza_2307228983800890538.jpeg/30x30bb.jpg",
+						"_60w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/04/c1/48/04c1486a-6637-00de-6e89-264b48ed82f7/mza_2307228983800890538.jpeg/60x60bb.jpg",
+						"_100w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/04/c1/48/04c1486a-6637-00de-6e89-264b48ed82f7/mza_2307228983800890538.jpeg/100x100bb.jpg",
+						"_600w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/04/c1/48/04c1486a-6637-00de-6e89-264b48ed82f7/mza_2307228983800890538.jpeg/600x600bb.jpg"
+					}
+				},
+				{
+					"id": "1443675475",
+					"title": "The Veil Audio Drama",
+					"genre": "Performing Arts",
+					"publisher": {
+						"id": null,
+						"name": "Voxx Studios"
+					},
+					"iTunesUrl": "https://podcasts.apple.com/us/podcast/the-veil-audio-drama/id1443675475?uo=4",
+					"feedUrl": "https://theveilaudio.libsyn.com/rss",
+					"thumbnail": {
+						"_30w": "https://is2-ssl.mzstatic.com/image/thumb/Podcasts123/v4/ca/b7/6e/cab76ecf-e0b3-fe2d-1c17-7a1697b679ed/mza_3446169558695366007.png/30x30bb.jpg",
+						"_60w": "https://is2-ssl.mzstatic.com/image/thumb/Podcasts123/v4/ca/b7/6e/cab76ecf-e0b3-fe2d-1c17-7a1697b679ed/mza_3446169558695366007.png/60x60bb.jpg",
+						"_100w": "https://is2-ssl.mzstatic.com/image/thumb/Podcasts123/v4/ca/b7/6e/cab76ecf-e0b3-fe2d-1c17-7a1697b679ed/mza_3446169558695366007.png/100x100bb.jpg",
+						"_600w": "https://is2-ssl.mzstatic.com/image/thumb/Podcasts123/v4/ca/b7/6e/cab76ecf-e0b3-fe2d-1c17-7a1697b679ed/mza_3446169558695366007.png/600x600bb.jpg"
+					}
+				}
+			]
+		}
+	}
+}

--- a/core/search/__fixtures__/search-results-with-more.json
+++ b/core/search/__fixtures__/search-results-with-more.json
@@ -1,0 +1,81 @@
+{
+	"data": {
+		"searchPodcasts": {
+			"term": "vox",
+			"startIndex": 0,
+			"nextOffset": 5,
+			"results": [
+				{
+					"id": "1042433083",
+					"title": "The Weeds",
+					"genre": "Politics",
+					"publisher": { "id": "1439215748", "name": "Vox" },
+					"iTunesUrl": "https://podcasts.apple.com/us/podcast/the-weeds/id1042433083?uo=4",
+					"feedUrl": "https://feeds.megaphone.fm/theweeds",
+					"thumbnail": {
+						"_30w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts113/v4/c6/89/4c/c6894cfa-5084-c9fe-3c72-666978686bb4/mza_1739210204902964516.png/30x30bb.jpg",
+						"_60w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts113/v4/c6/89/4c/c6894cfa-5084-c9fe-3c72-666978686bb4/mza_1739210204902964516.png/60x60bb.jpg",
+						"_100w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts113/v4/c6/89/4c/c6894cfa-5084-c9fe-3c72-666978686bb4/mza_1739210204902964516.png/100x100bb.jpg",
+						"_600w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts113/v4/c6/89/4c/c6894cfa-5084-c9fe-3c72-666978686bb4/mza_1739210204902964516.png/600x600bb.jpg"
+					}
+				},
+				{
+					"id": "1081584611",
+					"title": "The Ezra Klein Show",
+					"genre": "Philosophy",
+					"publisher": { "id": "1439215748", "name": "Vox" },
+					"iTunesUrl": "https://podcasts.apple.com/us/podcast/the-ezra-klein-show/id1081584611?uo=4",
+					"feedUrl": "https://feeds.megaphone.fm/theezrakleinshow",
+					"thumbnail": {
+						"_30w": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts113/v4/7a/17/0f/7a170fc0-97ae-64be-eeb7-9ecf9330581d/mza_1082450096055116974.png/30x30bb.jpg",
+						"_60w": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts113/v4/7a/17/0f/7a170fc0-97ae-64be-eeb7-9ecf9330581d/mza_1082450096055116974.png/60x60bb.jpg",
+						"_100w": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts113/v4/7a/17/0f/7a170fc0-97ae-64be-eeb7-9ecf9330581d/mza_1082450096055116974.png/100x100bb.jpg",
+						"_600w": "https://is4-ssl.mzstatic.com/image/thumb/Podcasts113/v4/7a/17/0f/7a170fc0-97ae-64be-eeb7-9ecf9330581d/mza_1082450096055116974.png/600x600bb.jpg"
+					}
+				},
+				{
+					"id": "1294325824",
+					"title": "The Impact",
+					"genre": "Documentary",
+					"publisher": { "id": "1439215748", "name": "Vox" },
+					"iTunesUrl": "https://podcasts.apple.com/us/podcast/the-impact/id1294325824?uo=4",
+					"feedUrl": "https://feeds.megaphone.fm/impact",
+					"thumbnail": {
+						"_30w": "https://is2-ssl.mzstatic.com/image/thumb/Podcasts113/v4/24/ef/39/24ef396a-1ae5-6e79-e661-20fdea200f93/mza_3156222670743834797.png/30x30bb.jpg",
+						"_60w": "https://is2-ssl.mzstatic.com/image/thumb/Podcasts113/v4/24/ef/39/24ef396a-1ae5-6e79-e661-20fdea200f93/mza_3156222670743834797.png/60x60bb.jpg",
+						"_100w": "https://is2-ssl.mzstatic.com/image/thumb/Podcasts113/v4/24/ef/39/24ef396a-1ae5-6e79-e661-20fdea200f93/mza_3156222670743834797.png/100x100bb.jpg",
+						"_600w": "https://is2-ssl.mzstatic.com/image/thumb/Podcasts113/v4/24/ef/39/24ef396a-1ae5-6e79-e661-20fdea200f93/mza_3156222670743834797.png/600x600bb.jpg"
+					}
+				},
+				{
+					"id": "934552872",
+					"title": "Switched on Pop",
+					"genre": "Music Commentary",
+					"publisher": { "id": "1439215748", "name": "Vox" },
+					"iTunesUrl": "https://podcasts.apple.com/us/podcast/switched-on-pop/id934552872?uo=4",
+					"feedUrl": "https://feeds.megaphone.fm/switchedonpop",
+					"thumbnail": {
+						"_30w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/f3/d1/22/f3d12254-e15b-4b1b-6558-74470f0b93ae/mza_2025196989843407248.png/30x30bb.jpg",
+						"_60w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/f3/d1/22/f3d12254-e15b-4b1b-6558-74470f0b93ae/mza_2025196989843407248.png/60x60bb.jpg",
+						"_100w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/f3/d1/22/f3d12254-e15b-4b1b-6558-74470f0b93ae/mza_2025196989843407248.png/100x100bb.jpg",
+						"_600w": "https://is3-ssl.mzstatic.com/image/thumb/Podcasts123/v4/f3/d1/22/f3d12254-e15b-4b1b-6558-74470f0b93ae/mza_2025196989843407248.png/600x600bb.jpg"
+					}
+				},
+				{
+					"id": "1248862589",
+					"title": "Worldly",
+					"genre": "Politics",
+					"publisher": { "id": "1439215748", "name": "Vox" },
+					"iTunesUrl": "https://podcasts.apple.com/us/podcast/worldly/id1248862589?uo=4",
+					"feedUrl": "https://feeds.megaphone.fm/worldly",
+					"thumbnail": {
+						"_30w": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/08/2e/07/082e079a-cabf-db62-3fea-a74cc8a1b594/mza_1165648460994853372.png/30x30bb.jpg",
+						"_60w": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/08/2e/07/082e079a-cabf-db62-3fea-a74cc8a1b594/mza_1165648460994853372.png/60x60bb.jpg",
+						"_100w": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/08/2e/07/082e079a-cabf-db62-3fea-a74cc8a1b594/mza_1165648460994853372.png/100x100bb.jpg",
+						"_600w": "https://is5-ssl.mzstatic.com/image/thumb/Podcasts123/v4/08/2e/07/082e079a-cabf-db62-3fea-a74cc8a1b594/mza_1165648460994853372.png/600x600bb.jpg"
+					}
+				}
+			]
+		}
+	}
+}

--- a/core/search/useSearch.js
+++ b/core/search/useSearch.js
@@ -1,0 +1,170 @@
+import { useReducer, useCallback, useMemo, useRef } from "react";
+import { useStoreActions } from "easy-peasy";
+import uniqBy from "lodash/fp/uniqBy";
+
+export const SearchStatus = {
+	OK: "OK",
+	LOADING_NEW: "LOADING_NEW",
+	FAILED_NEW: "FAILED_NEW",
+	LOADING_MORE: "LOADING_MORE",
+	FAILED_MORE: "FAILED_MORE"
+};
+
+export const SearchAction = {
+	LOAD_NEW: "LOAD_NEW",
+	REJECT_NEW: "REJECT_NEW",
+	RECEIVE_NEW: "RECEIVE_NEW",
+	LOAD_MORE: "LOAD_MORE",
+	REJECT_MORE: "REJECT_MORE",
+	RECEIVE_MORE: "RECEIVE_MORE",
+	RESET: "RESET"
+};
+
+const INITIAL_DATA = {
+	term: "",
+	startIndex: 0,
+	nextOffset: null,
+	results: []
+};
+
+function init({ initialTerm, initialValue }) {
+	const initialState = {
+		status: SearchStatus.OK,
+		term: initialTerm,
+		focusOnResult: null,
+		nextOffset: null,
+		results: [],
+		error: null
+	};
+
+	if (initialValue instanceof Error) {
+		initialState.status = SearchStatus.FAILED_NEW;
+		initialState.error = initialValue;
+	} else {
+		Object.assign(initialState, {
+			nextOffset: initialValue.nextOffset,
+			results: initialValue.results
+		});
+	}
+
+	return initialState;
+}
+
+const dedupe = uniqBy("id");
+
+function reducer(state, action) {
+	switch (action.type) {
+		case SearchAction.LOAD_NEW:
+			return {
+				...state,
+				term: action.payload,
+				status: SearchStatus.LOADING_NEW,
+				results: [],
+				nextOffset: null
+			};
+		case SearchAction.REJECT_NEW:
+			return {
+				...state,
+				status: SearchStatus.FAILED_NEW,
+				error: action.payload
+			};
+		case SearchAction.RECEIVE_NEW:
+			return {
+				...state,
+				status: SearchStatus.OK,
+				results: action.payload.results,
+				nextOffset: action.payload.nextOffset
+			};
+		case SearchAction.LOAD_MORE:
+			return {
+				...state,
+				status: SearchStatus.LOADING_MORE
+			};
+		case SearchAction.REJECT_MORE:
+			return {
+				...state,
+				status: SearchStatus.FAILED_MORE,
+				error: action.payload
+			};
+		case SearchAction.RECEIVE_MORE:
+			return {
+				...state,
+				status: SearchStatus.OK,
+				results: dedupe([...state.results, ...action.payload.results]),
+				// move focus to the first new result
+				focusOnResult: state.results.length,
+				nextOffset: action.payload.nextOffset
+			};
+		case SearchAction.RESET:
+			return init({ initialTerm: "", initialValue: INITIAL_DATA });
+		default:
+			throw new Error();
+	}
+}
+
+export default function useSearch({
+	initialTerm = "",
+	initialValue = INITIAL_DATA
+}) {
+	const controller = useRef({ abort() {} });
+	const [state, dispatch] = useReducer(
+		reducer,
+		{ initialTerm, initialValue },
+		init
+	);
+
+	const searchPodcasts = useStoreActions(actions => actions.podcasts.search);
+
+	const updateSearchTerm = useCallback(
+		term => {
+			controller.current.abort();
+
+			if (!term) {
+				dispatch({ type: SearchAction.RESET });
+			} else {
+				controller.current = new AbortController();
+				dispatch({ type: SearchAction.LOAD_NEW, payload: term });
+				searchPodcasts({ term, signal: controller.current.signal })
+					.then(data => {
+						dispatch({ type: SearchAction.RECEIVE_NEW, payload: data });
+					})
+					.catch(error => {
+						if (error.name !== "AbortError") {
+							dispatch({ type: SearchAction.REJECT_NEW, payload: error });
+						}
+					});
+			}
+		},
+		[searchPodcasts]
+	);
+
+	const loadMoreResults = useCallback(() => {
+		if (state.nextOffset !== null) {
+			controller.current.abort();
+			controller.current = new AbortController();
+			dispatch({ type: SearchAction.LOAD_MORE });
+			searchPodcasts({
+				term: state.term,
+				offset: state.nextOffset,
+				signal: controller.current.signal
+			})
+				.then(data => {
+					dispatch({ type: SearchAction.RECEIVE_MORE, payload: data });
+				})
+				.catch(error => {
+					if (error.name !== "AbortError") {
+						dispatch({ type: SearchAction.REJECT_MORE, payload: error });
+					}
+				});
+		}
+	}, [searchPodcasts, state.nextOffset, state.term]);
+
+	return useMemo(
+		() => ({
+			...state,
+			updateSearchTerm,
+			loadMoreResults: state.nextOffset && loadMoreResults
+		}),
+		[state, loadMoreResults, updateSearchTerm]
+	);
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -22,10 +22,10 @@ class App extends NextApp {
 			);
 		}
 
-		const pageProps = await super.getInitialProps({ ctx, Component });
+		const props = await super.getInitialProps({ ctx, Component });
 
 		return {
-			...pageProps,
+			...props,
 			initialState: ctx.store.getState()
 		};
 	}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,3 +1,4 @@
+import "abort-controller/polyfill";
 import React from "react";
 import NextApp from "next/app";
 import NavBar from "../core/nav/Navbar";


### PR DESCRIPTION
This PR builds on the search feature implemented in #8 by adding permalinks and pagination. 

Permalinks are achieved by updating the `q` parameter in the URL query string to match the search term as the user types. The `getInitialProps` method on the Search component then uses this query string to fetch results ahead of time and server render them. This means the response for a URL like `/search?q=vox` will already have the first 25 results for "vox" rendered.

Pagination is achieved by displaying a "Load More Results" button at the bottom of the results list if there are more result to fetch. Loading and error states are handled gracefully, and on success, focus is moved to the first new result.

Lastly, this PR teaches the search feature to update the client store with all fetched podcasts. This fulfills the final requirement for search laid out in #7, and therefore this PR closes #7.